### PR TITLE
Add missing error to PriceFeedMock

### DIFF
--- a/packages/test-devtools-evm-foundry/contracts/mocks/PriceFeedMock.sol
+++ b/packages/test-devtools-evm-foundry/contracts/mocks/PriceFeedMock.sol
@@ -28,6 +28,8 @@ contract PriceFeedMock is ILayerZeroPriceFeed, Ownable {
 
     ILayerZeroEndpointV2 public endpoint;
 
+    error LZ_PriceFeed_NotAnOPStack(uint32 l2Eid);
+
     // ============================ Constructor ===================================
 
     // @dev oz4/5 breaking change... Ownable constructor


### PR DESCRIPTION
Adds missing error definition for the error `LZ_PriceFeed_NotAnOPStack` which is used in `PriceFeedMock._getL1LookupId()` and currently causing issues (https://github.com/LayerZero-Labs/devtools/issues/978).
```
Error: 
Compiler run failed:
Error (7576): Undeclared identifier.
   --> lib/devtools/packages/test-devtools-evm-foundry/contracts/mocks/PriceFeedMock.sol:184:16:
    |
184 |         revert LZ_PriceFeed_NotAnOPStack(l2Eid);
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^

```
The alternative would be to add it in `ILayerZeroPriceFeed` where the error `LZ_PriceFeed_UnknownL2Eid` which was previously used is defined, but since `LZ_PriceFeed_NotAnOPStack` seems to only be used in this mock and not in layerzero v2 adding it here seems to be the way to go.